### PR TITLE
small Tensorboard fix

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -201,7 +201,7 @@ class ModelTrainer:
                 from torch.utils.tensorboard import SummaryWriter
 
                 if tensorboard_log_dir is not None and not os.path.exists(tensorboard_log_dir):
-                    os.mkdir(tensorboard_log_dir)
+                    os.makedirs(tensorboard_log_dir)
                 writer = SummaryWriter(log_dir=tensorboard_log_dir, comment=tensorboard_comment)
                 log.info(f"tensorboard logging path is {tensorboard_log_dir}")
 


### PR DESCRIPTION
Small fix for Tensorboard logging to be able to create subdirs to do grid-search on multiple models. Each model/hyper-parameters will have its own subfolder under `runs/`